### PR TITLE
Fix multiple Vale process spawning issue

### DIFF
--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -92,6 +92,16 @@ interface valeArgs {
 }
 
 export async function activate(context: ExtensionContext) {
+  // Prevent multiple activations - stop existing client if present
+  if (client) {
+    console.log("Vale language client already active, stopping existing client");
+    try {
+      await client.stop();
+    } catch (error) {
+      console.error("Error stopping existing client:", error);
+    }
+  }
+
   let filePath = path.join(context.extensionPath, "vale-ls");
 
   // Handle Windows
@@ -214,9 +224,15 @@ export async function activate(context: ExtensionContext) {
   }
 }
 
-export function deactivate(): Thenable<void> | undefined {
+export async function deactivate(): Promise<void> {
   if (!client) {
-    return undefined;
+    return;
   }
-  return client.stop();
+
+  try {
+    await client.stop();
+    console.log("Vale language server stopped");
+  } catch (error) {
+    console.error("Error stopping Vale language server:", error);
+  }
 }


### PR DESCRIPTION
This PR fixes the regression of issue #17 (originally resolved in PR #18), where multiple Vale processes spawn and consume excessive CPU resources.

The current LSP-based implementation in src/lsp.ts lacks protection against multiple activations. When the activate() function is called multiple times (which can happen during workspace reloads, configuration changes, or other VSCode events), it creates a new LanguageClient and spawns a new vale-ls process without stopping the previous one. This leads to:

  - Multiple vale-ls processes accumulating over time
  - Excessive CPU usage
  - Poor extension performance

This PR adds proper client lifecycle management to prevent multiple process spawning:

  1. Activation Guard (lines 95-103): Before creating a new client, check if one already exists. If it does,
  properly stop the existing client before proceeding.
  2. Improved Deactivation (lines 223-234): Enhanced the deactivate() function to use async/await with proper error
  handling, ensuring the language server process is cleanly stopped.
  3. Better Logging: Added console logging for debugging client lifecycle events.