### PR TITLE
fix: share one registration of the server's commands across folders

### DIFF
--- a/src/languageServer.ts
+++ b/src/languageServer.ts
@@ -19,6 +19,7 @@ import {
   sha256Hex,
   buildDockerProxyEnvironment,
   isUnsupportedLinuxLibc,
+  SharedRegistry,
 } from "./utils";
 import type { ValeExecutionOptions } from "./utils";
 import { buildValeConfig, resolveValeExecutionOptions } from "./config";
@@ -32,6 +33,7 @@ import { getValeOutputChannel } from "./ui";
 import { getValeVersionOutput } from "./cli";
 
 import {
+  ExecuteCommandRequest,
   LanguageClient,
   LanguageClientOptions,
   ServerOptions,
@@ -40,14 +42,70 @@ import {
 /**
  * Downloading, installing, and running vale-ls.
  *
- * vale-ls does not support the `workspace/workspaceFolders` capability, so
- * (per VS Code's standard guidance for such servers) we run one client per
- * workspace folder, each restricted to that folder's files, rather than a
- * single client shared across the whole window. See
- * `.claude/notes/multi-root-workspaces.md`.
+ * One client runs per workspace folder, each restricted to that folder's
+ * files. vale-ls v0.5.0+ supports `workspace/workspaceFolders` itself, so a
+ * single shared client is possible -- but per-client `initializationOptions`
+ * are what let folder-scoped settings (a per-folder `vale.valeCLI.config`)
+ * take effect, so collapsing to one client trades that away.
  */
 const clients: Map<string, LanguageClient> = new Map();
 const VERSION_MARKER_NAME = ".vale-ls-version";
+
+/**
+ * vale-ls advertises its commands (`cli.sync`, ...) through the
+ * `executeCommandProvider` capability, and vscode-languageclient registers
+ * each one with VS Code. Every folder's server advertises the same names, so
+ * the second client's registration throws (`command 'cli.sync' already
+ * exists`) and that folder's client dies on startup.
+ *
+ * So that registration is disabled per client, and each command is instead
+ * registered once here, with a handler that routes to the client for the
+ * active editor's folder - which the per-client registration never did.
+ */
+const sharedServerCommands = new SharedRegistry<vscode.Disposable>(
+  (command) =>
+    vscode.commands.registerCommand(command, (...args: unknown[]) => {
+      return clientForActiveEditor()?.sendRequest(ExecuteCommandRequest.type, {
+        command,
+        arguments: args,
+      });
+    }),
+  (disposable) => disposable.dispose()
+);
+
+/** The client responsible for the active editor's folder. */
+function clientForActiveEditor(): LanguageClient | undefined {
+  const uri = vscode.window.activeTextEditor?.document.uri;
+  if (uri) {
+    const folder = vscode.workspace.getWorkspaceFolder(uri);
+    if (folder) {
+      const scoped = clients.get(clientKeyFor(folder));
+      if (scoped) {
+        return scoped;
+      }
+    }
+  }
+  return clients.get(noFolderClientKey()) ?? clients.values().next().value;
+}
+
+/** Keeps the client from registering the server's commands itself. */
+function suppressCommandRegistration(client: LanguageClient): void {
+  const feature = client.getFeature(ExecuteCommandRequest.method);
+  (feature as unknown as { initialize: () => void }).initialize = () => {};
+}
+
+/** Registers the started client's advertised commands, once per name. */
+function shareServerCommands(client: LanguageClient): void {
+  const commands =
+    client.initializeResult?.capabilities.executeCommandProvider?.commands ??
+    [];
+  sharedServerCommands.acquire(client, commands);
+}
+
+/** Lets go of a stopping client's commands, disposing the last reference. */
+function releaseServerCommands(client: LanguageClient): void {
+  sharedServerCommands.release(client);
+}
 
 function runtimeGlibcVersion(): string | undefined {
   const report = process.report?.getReport();
@@ -277,6 +335,7 @@ export async function stopAndRemoveClient(key: string): Promise<void> {
     return;
   }
   clients.delete(key);
+  releaseServerCommands(existing);
   try {
     await existing.stop();
   } catch (error) {
@@ -398,10 +457,12 @@ export async function startClientForFolder(
   const clientName = folder ? `Vale VSCode (${folder.name})` : "Vale VSCode";
 
   const client = new LanguageClient(clientId, clientName, serverOptions, clientOptions);
+  suppressCommandRegistration(client);
   clients.set(key, client);
 
   try {
     await client.start();
+    shareServerCommands(client);
   } catch (err) {
     console.error(err);
     logDiagnostic(

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 
 import {
   EXPECTED_CHECKSUMS,
+  SharedRegistry,
   buildDockerRunArgs,
   buildDockerWrapperScript,
   buildDownloadAssetName,
@@ -518,4 +519,59 @@ describe("buildDockerWrapperScript", () => {
     assert.ok(script.includes(`'/path with spaces/root:/path with spaces/root'`));
   });
 
+});
+
+describe("SharedRegistry", () => {
+  // Regression coverage for the multi-root startup failure: every folder's
+  // vale-ls advertises the same command names (`cli.sync`, ...), and
+  // registering a name twice with VS Code throws, killing the second
+  // folder's client. The registry gives each name one registration shared
+  // by every client, disposed only when the last client releases it.
+  test("creates each name once across owners", () => {
+    const created: string[] = [];
+    const registry = new SharedRegistry<string>(
+      (name) => {
+        created.push(name);
+        return name;
+      },
+      () => {}
+    );
+
+    registry.acquire("vale", ["cli.sync", "cli.compile"]);
+    registry.acquire("harper", ["cli.sync", "cli.compile"]);
+
+    assert.deepEqual(created, ["cli.sync", "cli.compile"]);
+    assert.ok(registry.has("cli.sync"));
+  });
+
+  test("disposes a name only when its last owner releases it", () => {
+    const destroyed: string[] = [];
+    const registry = new SharedRegistry<string>(
+      (name) => name,
+      (value) => destroyed.push(value)
+    );
+
+    registry.acquire("vale", ["cli.sync"]);
+    registry.acquire("harper", ["cli.sync"]);
+
+    registry.release("vale");
+    assert.deepEqual(destroyed, []);
+    assert.ok(registry.has("cli.sync"));
+
+    registry.release("harper");
+    assert.deepEqual(destroyed, ["cli.sync"]);
+    assert.equal(registry.has("cli.sync"), false);
+  });
+
+  test("tolerates releasing an unknown owner", () => {
+    const registry = new SharedRegistry<string>(
+      (name) => name,
+      () => {}
+    );
+    registry.release("never-acquired");
+    registry.acquire("vale", ["cli.sync"]);
+    registry.release("vale");
+    registry.release("vale");
+    assert.equal(registry.has("cli.sync"), false);
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -410,3 +410,56 @@ export function resolveConfigPath(
 
   return resolvedConfigPath;
 }
+
+/**
+ * A reference-counted registry of shared registrations.
+ *
+ * Every workspace folder's vale-ls advertises the same command names, and a
+ * name can only be registered with VS Code once - so the first owner
+ * registers it, later owners share it, and the registration is disposed when
+ * the last owner releases it. Pure bookkeeping, so the routing in
+ * `languageServer.ts` stays testable.
+ */
+export class SharedRegistry<T> {
+  private entries = new Map<string, { value: T; refs: number }>();
+  private owned = new Map<unknown, string[]>();
+
+  constructor(
+    private create: (name: string) => T,
+    private destroy: (value: T) => void
+  ) {}
+
+  /** Registers `names` for `owner`, creating each name's value on first use. */
+  acquire(owner: unknown, names: string[]): void {
+    this.owned.set(owner, names);
+    for (const name of names) {
+      const existing = this.entries.get(name);
+      if (existing) {
+        existing.refs += 1;
+        continue;
+      }
+      this.entries.set(name, { value: this.create(name), refs: 1 });
+    }
+  }
+
+  /** Releases `owner`'s names, destroying any it held the last claim on. */
+  release(owner: unknown): void {
+    const names = this.owned.get(owner) ?? [];
+    this.owned.delete(owner);
+    for (const name of names) {
+      const entry = this.entries.get(name);
+      if (!entry) {
+        continue;
+      }
+      entry.refs -= 1;
+      if (entry.refs <= 0) {
+        this.destroy(entry.value);
+        this.entries.delete(name);
+      }
+    }
+  }
+
+  has(name: string): boolean {
+    return this.entries.has(name);
+  }
+}


### PR DESCRIPTION
Every folder's vale-ls advertises the same command names (`cli.sync`, ...), and vscode-languageclient registers each with VS Code per client -- so in a multi-root window the second client threw `command 'cli.sync' already exists` and died on startup.

Each name is now registered once, reference-counted across clients, and routed to the client for the active editor's folder -- which the per-client registration never did: whichever client registered first received every folder's commands. The last client to stop disposes the registration.